### PR TITLE
Remove 'for' argument from tag

### DIFF
--- a/fluent_comments/templates/comments/form.html
+++ b/fluent_comments/templates/comments/form.html
@@ -12,7 +12,7 @@
       <div class="form-actions">
         <input type="submit" name="post" class="btn btn-primary" value="{% trans "Post" %}" />
         <input type="submit" name="preview" class="btn" value="{% trans "Preview" %}" />
-        {% ajax_comment_tags for form.target_object %}
+        {% ajax_comment_tags form.target_object %}
       </div>
     </form>
 {% endif %}

--- a/fluent_comments/templatetags/fluent_comments_tags.py
+++ b/fluent_comments/templatetags/fluent_comments_tags.py
@@ -9,7 +9,7 @@ from fluent_comments.moderation import comments_are_open, comments_are_moderated
 register = Library()
 
 @register.inclusion_tag("fluent_comments/templatetags/ajax_comment_tags.html", takes_context=True)
-def ajax_comment_tags(context, for_, target_object):
+def ajax_comment_tags(context, target_object):
     """
     Display the required ``<div>`` elements to let the Ajax comment functionality work with your form.
     """


### PR DESCRIPTION
Hi,

I've just started using **django-fluent-comments**. I'm a big fan as the Ajax approach allows me to leave my views alone :) And it works really well.

I ended up using the latest on `master` and I came across this problem running Django 1.6.8 and Python 2.6. It seems that the custom tag doesn't really handle the use of `for` in the tag usage as it tries to resolve `for` as a context variable instead of leaving it as syntax.

I've opted for a fairly dull fix here. I guess ideally we'd write a tag that properly supported the syntax but I'm not experienced with writing such tags with the Django API and I doubt you want to depend on something like django-classy-tags.

As a separate note, I've also ended up removing a lot of the 'fadeIn' stuff from the Javascript as I am not partial to the look. I've just commented it out for the moment but if you'd like a pull request which makes it optional then I could try my hand at that.

Thanks again, it is a great project which has been super easy to use,
Michael