### PR TITLE
Look for the right #id_parent.

### DIFF
--- a/fluent_comments/static/fluent_comments/js/ajaxcomments.js
+++ b/fluent_comments/static/fluent_comments/js/ajaxcomments.js
@@ -164,7 +164,7 @@
 
         removeThreadedPreview();
         $('.js-comments-form').appendTo($comment);
-        $('#id_parent').val(comment_id);
+        $($comment.find('#id_parent')[0]).val(comment_id);
     }
 
 


### PR DESCRIPTION
When showing threaded reply, the relevant ``#id_parent`` should be targeted instead. I wanted to plug in the threaded comment into my Django admin's change form and had another field for the model instance called parent and it was targeted first by ``$('#id_parent').val(comment_id)``.