### PR TITLE
Fix wildcard import from threadedcomments in __init__

### DIFF
--- a/fluent_comments/__init__.py
+++ b/fluent_comments/__init__.py
@@ -13,7 +13,8 @@ __version__ = "1.0.4"
 if appsettings.USE_THREADEDCOMMENTS:
     # Extend the API provided by django-threadedcomments,
     # in case this app uses more hooks of Django's custom comment app API.
-    from threadedcomments import *
+    from threadedcomments.models import *
+    from threadedcomments.forms import *
 
 
 def get_model():


### PR DESCRIPTION
See https://github.com/HonzaKral/django-threadedcomments/pull/74
The upcoming version removed top level import, so ee have to fine-grain them. This change is compatible with the old versions.