### PR TITLE
Fixes admin list error when the referenced object no longer exist.

### DIFF
--- a/fluent_comments/admin.py
+++ b/fluent_comments/admin.py
@@ -67,12 +67,20 @@ class FluentCommentsAdmin(CommentsAdminBase):
         return super(FluentCommentsAdmin, self).get_queryset(request).select_related('user')
 
     def object_link(self, comment):
-        object = comment.content_object
+        try:
+            object = comment.content_object
+        except AttributeError:
+            return ''
+
         if sys.version_info[0] >= 3:
             title = str(object)
         else:
             title = unicode(object)
-        return u'<a href="{0}">{1}</a>'.format(escape(object.get_absolute_url()), escape(title))
+
+        if object:
+            return u'<a href="{0}">{1}</a>'.format(escape(object.get_absolute_url()), escape(title))
+        else:
+            return u''
 
     object_link.short_description = _("Page")
     object_link.allow_tags = True


### PR DESCRIPTION
When a `content_object` a comment is referring to no longer exists the
`comment.content_object` call sometimes returns `None` which means a
`get_absolute_url` call will fail. In other occurences if it no longer
exists it can raise an `AttributeError` when trying to retrieve the
object as `get_object_for_this_type` gets called and
`self.model_class()` returns `None` in the line.