### PR TITLE
Compatibility fixes with Django 1.9, Travis testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+include = fluent_comments*

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-pro
+repo_token: NYefOmqPlep2cS55RbgiFrLekn2y6JYpW

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+sudo: false
+language: python
+env:
+  - DJANGO_VERSION="Django>=1.7,<1.8"
+  - DJANGO_VERSION="Django>=1.8,<1.9"
+  - DJANGO_VERSION="Django>=1.9,<1.10"
+  - DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
+python:
+  - "2.6"
+  - "2.7"
+  - "3.4"
+  - "3.5"
+before_script:
+  - pip install coverage coveralls
+  - pip install -r example/requirements.txt
+  - pip install -q "$DJANGO_VERSION"
+script: 
+  - python setup.py install
+  - coverage run example/manage.py test
+after_script:
+  - coveralls
+matrix:
+  exclude:
+    # Django >= 1.7 does not support Python 2.6
+    - python: "2.6"
+      env: DJANGO_VERSION="Django>=1.7,<1.8"
+    - python: "2.6"
+      env: DJANGO_VERSION="Django>=1.8,<1.9"
+    - python: "2.6"
+      env: DJANGO_VERSION="Django>=1.9,<1.10"
+    - python: "2.6"
+      env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'
+    # Django < 1.8 does not support Python 3.5
+    - python: "3.5"
+      env: DJANGO_VERSION="Django>=1.7,<1.8"
+  allow_failures:
+     - env: DJANGO_VERSION='https://github.com/django/django/archive/master.tar.gz'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@ Version 1.1 (2015-12-28)
 ------------------------
 
 * Fix Django 1.9 issue with imports.
+* Fix error in the admin for non-existing objects.
+* Fix Python 3 installation error (dropped Akismet_ requirement).
 * Drop Django 1.4 compatibility (in the templates).
 
 

--- a/README.rst
+++ b/README.rst
@@ -187,7 +187,7 @@ The IP Address is read from the ``REMOTE_ADDR`` meta field.
 In case your site is behind a HTTP proxy (e.g. using Gunicorn or a load balancer),
 this would make all comments appear to be posted from the load balancer IP.
 
-The best, and more secure, way to fix this, is using WsgiUnproxy_ middleware in your ``wsgi.py``:
+The best and most secure way to fix this, is using WsgiUnproxy_ middleware in your ``wsgi.py``:
 
 .. code-block:: python
 
@@ -198,7 +198,8 @@ The best, and more secure, way to fix this, is using WsgiUnproxy_ middleware in 
     application = get_wsgi_application()
     application = unproxy(trusted_proxies=settings.TRUSTED_X_FORWARDED_FOR_IPS)(application)
 
-In your ``settings.py``, you can define which hosts are trusted. For example:
+In your ``settings.py``, you can define which hosts may pass the ``X-Forwarded-For``
+header in the HTTP request. For example:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,17 @@ The following settings are available for comment moderation::
 
 To use Akismet_ moderation, make sure the ``AKISMET_API_KEY`` setting is defined.
 
+Python 3 notes
+~~~~~~~~~~~~~~
+
+The ``akismet`` 0.2 release does not support Python 3.
+Hence, it's only installed for Python 2 environments.
+
+For Python 3 systems, install one of the forks from the Akismet_ library
+to have proper Python 3 support. For example by including the following in your ``requirements.txt``::
+
+    -e git+https://github.com/allieus/python-akismet.git#egg=akismet
+
 
 E-mail notification
 -------------------

--- a/example/article/fixtures/data.json
+++ b/example/article/fixtures/data.json
@@ -1,0 +1,62 @@
+[
+    {
+        "fields": {
+            "content": "This is testing article",
+            "enable_comments": true,
+            "publication_date": "2016-01-04T15:48:50",
+            "slug": "testing-article",
+            "title": "Testing article"
+        },
+        "model": "article.article",
+        "pk": 1
+    },
+    {
+        "fields": {
+            "date_joined": "2016-01-04T15:48:04.204",
+            "email": "p@d.cz",
+            "first_name": "",
+            "groups": [],
+            "is_active": true,
+            "is_staff": true,
+            "is_superuser": true,
+            "last_login": "2016-01-04T15:48:09.458",
+            "last_name": "",
+            "password": "pbkdf2_sha256$20000$uUUDqBsJ2P6O$5x49IXC6i4C5ysNhUP9cwZ/9ieReUHKSFVbHsrVC9v4=",
+            "user_permissions": [],
+            "username": "pdlouhy"
+        },
+        "model": "auth.user",
+        "pk": 1
+    },
+    {
+        "fields": {
+            "comment": "Comment",
+            "content_type": 8,
+            "ip_address": "127.0.0.1",
+            "is_public": true,
+            "is_removed": false,
+            "object_pk": "1",
+            "site": 1,
+            "submit_date": "2016-01-04T16:00:42.071",
+            "user": 1,
+            "user_email": "petr.dlouhy@auto-mat.cz",
+            "user_name": "Petr",
+            "user_url": "http://www.google.com"
+        },
+        "model": "django_comments.comment",
+        "pk": 1
+    },
+    {
+        "fields": {
+            "action_flag": 1,
+            "action_time": "2016-01-04T15:48:51.769",
+            "change_message": "",
+            "content_type": 8,
+            "object_id": "1",
+            "object_repr": "Testing article",
+            "user": 1
+        },
+        "model": "admin.logentry",
+        "pk": 1
+    }
+]

--- a/example/article/tests.py
+++ b/example/article/tests.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+# Author: Petr Dlouhý <petr.dlouhy@auto-mat.cz>
+#
+# Copyright (C) 2015 o.s. Auto*Mat
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+from django.test import TestCase, Client
+from django.core.urlresolvers import reverse
+from django.contrib.auth.models import User
+from freezegun import freeze_time
+
+
+class CommentsTests(TestCase):
+    fixtures = ["data", ]
+
+    def setUp(self):
+        self.admin = User.objects.create_superuser('superuser', 'myemail@test.com', 'secret')
+
+    def test_admin_comments_access(self):
+        self.client.login(username=self.admin.username, password='secret')
+        response = self.client.get(reverse('admin:fluent_comments_fluentcomment_changelist'))
+        self.assertContains(response, "Comment", status_code=200)
+
+    def test_get_article_with_comment(self):
+        response = self.client.get(reverse('article-details', kwargs={"slug": "testing-article"}))
+        self.assertContains(response, "Comment", status_code=200)
+
+    def test_get_article_with_comment(self):
+        response = self.client.get(reverse('article-details', kwargs={"slug": "testing-article"}))
+        self.assertContains(response, "Comment", status_code=200)
+
+    @freeze_time("2016-01-04 17:00:00")
+    def test_comment_post(self):
+        post_data = {
+            "content_type": "article.article",
+            "object_pk": 1,
+            "name": "Testing name",
+            "email": "test@email.com",
+            "comment": "Testing comment",
+            "timestamp": "1451919617",
+            "security_hash": "040d5412fd16c32983860e8796591a05a6856eb2",
+        }
+        response = self.client.post(reverse("comments-post-comment-ajax"), post_data, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertContains(response, "Testing comment", status_code=200)
+        self.assertEqual(response.status_code, 200, response.content.decode("utf-8"))

--- a/example/article/urls.py
+++ b/example/article/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import *
+from django.conf.urls import url
 from article.views import ArticleListView, ArticleFullListView, ArticleDetailView
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^detail/(?P<slug>[^/]+)/$', ArticleDetailView.as_view(), name='article-details'),
     url(r'^full/$', ArticleFullListView.as_view(), name='article-full-list'),
     url(r'^$', ArticleListView.as_view(), name='article-list'),
-)
+]

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,3 +1,5 @@
 Django>=1.4.10
 django-crispy-forms>=1.1.1
-akismet>=0.2
+#akismet>=0.2
+django-contrib-comments
+freezegun

--- a/example/settings.py
+++ b/example/settings.py
@@ -7,7 +7,6 @@ import sys
 sys.path.insert(0, dirname(dirname(realpath(__file__))))
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),
@@ -44,12 +43,21 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '-#@bi6bue%#1j)6+4b&#i0g-*xro@%f@_#zwv=2-g_@n3n_kj5'
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-#     'django.template.loaders.eggs.Loader',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            join(dirname(__file__), "templates"),
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'debug': DEBUG,
+            'context_processors': {
+                'django.contrib.auth.context_processors.auth'
+            }
+        },
+    },
+]
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
@@ -61,10 +69,6 @@ MIDDLEWARE_CLASSES = (
 
 
 ROOT_URLCONF = 'urls'
-
-TEMPLATE_DIRS = (
-    join(dirname(__file__), "templates"),
-)
 
 INSTALLED_APPS = (
     'django.contrib.auth',

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic import RedirectView
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     url(r'^admin/', include(admin.site.urls)),
 
@@ -11,4 +11,4 @@ urlpatterns = patterns('',
     url(r'^articles/', include('article.urls')),
 
     url(r'^$', RedirectView.as_view(url='articles/', permanent=False)),
-)
+]

--- a/fluent_comments/__init__.py
+++ b/fluent_comments/__init__.py
@@ -4,7 +4,7 @@ API for :ref:`custom-comment-app-api`
 from fluent_comments import appsettings
 
 # following PEP 440
-__version__ = "1.0.5"
+__version__ = "1.1"
 
 
 def get_model():

--- a/fluent_comments/admin.py
+++ b/fluent_comments/admin.py
@@ -66,12 +66,20 @@ class FluentCommentsAdmin(CommentsAdminBase):
         return super(FluentCommentsAdmin, self).get_queryset(request).select_related('user')
 
     def object_link(self, comment):
-        object = comment.content_object
+        try:
+            object = comment.content_object
+        except AttributeError:
+            return ''
+
         if sys.version_info[0] >= 3:
             title = str(object)
         else:
             title = unicode(object)
-        return u'<a href="{0}">{1}</a>'.format(escape(object.get_absolute_url()), escape(title))
+
+        if object:
+            return u'<a href="{0}">{1}</a>'.format(escape(object.get_absolute_url()), escape(title))
+        else:
+            return u''
 
     object_link.short_description = _("Page")
     object_link.allow_tags = True

--- a/fluent_comments/models.py
+++ b/fluent_comments/models.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.dispatch import receiver
 from django.template import RequestContext
-from django.template.loader import render_to_string
+from django.shortcuts import render
 from fluent_comments import appsettings
 from .compat import CommentManager, Comment, signals, get_model as get_comments_model
 
@@ -67,7 +67,7 @@ def on_comment_posted(sender, comment, request, **kwargs):
         'content_object': content_object
     }
 
-    message = render_to_string("comments/comment_notification_email.txt", context, RequestContext(request))
+    message = render(request, "comments/comment_notification_email.txt", context)
     send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, recipient_list, fail_silently=True)
 
 

--- a/fluent_comments/templatetags/fluent_comments_tags.py
+++ b/fluent_comments/templatetags/fluent_comments_tags.py
@@ -1,12 +1,16 @@
 from django.conf import settings
 from django.template import Library, Node
-from django.core import context_processors
 from django.template.loader import get_template
 from tag_parser import parse_token_kwargs
 from tag_parser.basetags import BaseInclusionNode
 from fluent_comments import appsettings
 from fluent_comments.models import get_comments_for_model
 from fluent_comments.moderation import comments_are_open, comments_are_moderated
+try:
+    from django.template import context_processors  # Django 1.10+
+except:
+    from django.core import context_processors
+
 
 register = Library()
 

--- a/fluent_comments/views.py
+++ b/fluent_comments/views.py
@@ -1,5 +1,4 @@
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.db import models
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.template.loader import render_to_string
 from django.template import RequestContext
@@ -46,7 +45,12 @@ def post_comment_ajax(request, using=None):
         return CommentPostBadRequest("Missing content_type or object_pk field.")
     try:
         object_pk = long(object_pk)
-        model = models.get_model(*ctype.split(".", 1))
+        try:
+            from django.db import models
+            model = models.get_model(*ctype.split(".", 1))
+        except:
+            from django.apps.registry import apps
+            model = apps.get_model(*ctype.split(".", 1))
         target = model._default_manager.using(using).get(pk=object_pk)
     except ValueError:
         return CommentPostBadRequest("Invalid object_pk value: {0}".format(escape(object_pk)))

--- a/fluent_comments/views.py
+++ b/fluent_comments/views.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.http import HttpResponse, HttpResponseBadRequest
+from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.template import RequestContext
 from django.utils.html import escape
@@ -139,7 +140,7 @@ def _ajax_result(request, form, action, comment=None, object_id=None):
             'preview': (action == 'preview'),
             'USE_THREADEDCOMMENTS': appsettings.USE_THREADEDCOMMENTS,
         }
-        comment_html = render_to_string('comments/comment.html', context, context_instance=RequestContext(request))
+        comment_html = render_to_string('comments/comment.html', context)
 
         json_return.update({
             'html': comment_html,

--- a/setup.py
+++ b/setup.py
@@ -33,31 +33,27 @@ def find_version(*parts):
         return str(version_match.group(1))
     raise RuntimeError("Unable to find version string.")
 
-install_requires = [
-    'django-crispy-forms>=1.1.1',
-    'django-tag-parser>=2.1',
-]
-
 if sys.version_info[0] >= 3:
     # Akismet 0.2 does not support Python 3.
     if 'install' in sys.argv or 'develop' in sys.argv:
         print("\nwarning: skipped Akismet as dependency because it does not have a Python 3 version.")
-else:
-    install_requires += [
-        'akismet>=0.2',
-        'django-contrib-comments>=1.5',
-    ]
+
 
 setup(
     name='django-fluent-comments',
     version=find_version('fluent_comments', '__init__.py'),
     license='Apache 2.0',
 
-    install_requires=install_requires,
+    install_requires = [
+        'django-crispy-forms>=1.1.1',
+        'django-tag-parser>=2.1',
+        'django-contrib-comments>=1.5',
+    ],
     requires=[
-        'Django (>=1.3)',   # Using staticfiles
+        'Django (>=1.5)',
     ],
     extras_require = {
+        ':python_version in "2.6,2.7"': ['akismet>=0.2',],
         'threadedcomments': ['django-threadedcomments>=1.0.1'],
     },
     description='A modern, ajax-based appearance for django_comments',


### PR DESCRIPTION
I have added few tests, and let them run by Travis and coverage reported to Coveralls.
The PR includes also fixes for remaining problems with Django 1.9 compatibility and few fixes for Django 1.10 (although the support is not complete).

After pulling this, you have to enable Travis tests and Coveralls support for your repository and change the Coveralls key in `.coveralls.yml`.